### PR TITLE
fix: validate existing venv before reusing it (issue #18)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -88,8 +88,37 @@ if (-not $PythonCmd) {
 # ── Step 2: Create venv ──
 Write-Step "Creating virtual environment..."
 
-if (Test-Path ".venv\Scripts\python.exe") {
-    Write-Ok "venv already exists, skipping"
+# Validate existing venv: even if python.exe is present, the venv could be
+# half-built, created with a different Python, or corrupted (see issue #18).
+# If it's broken, recreate it; otherwise reuse it.
+function Test-VenvHealthy {
+    param([string]$VenvPythonExe)
+    if (-not (Test-Path $VenvPythonExe)) { return $false }
+    try {
+        $ver = & $VenvPythonExe --version 2>&1
+        if ($LASTEXITCODE -ne 0) { return $false }
+        if ($ver -notmatch "Python \d+\.\d+") { return $false }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+$VenvPython = ".venv\Scripts\python.exe"
+if (Test-Path ".venv") {
+    if (Test-VenvHealthy $VenvPython) {
+        Write-Ok "Existing venv is healthy, reusing"
+    } else {
+        Write-Warn "Existing venv is broken or incomplete, recreating..."
+        Remove-Item -Recurse -Force .venv -ErrorAction SilentlyContinue
+        & $PythonCmd -m venv .venv
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err "Failed to create venv"
+            Read-Host "Press Enter to exit"
+            exit 1
+        }
+        Write-Ok "Created .venv"
+    }
 } else {
     & $PythonCmd -m venv .venv
     if ($LASTEXITCODE -ne 0) {
@@ -106,7 +135,11 @@ $Python = ".venv\Scripts\python.exe"
 # Upgrade pip first
 Write-Step "Upgrading pip..."
 & $Python -m pip install --upgrade pip --quiet
-Write-Ok "pip upgraded"
+if ($LASTEXITCODE -ne 0) {
+    Write-Warn "pip upgrade failed (non-critical, continuing with current pip)"
+} else {
+    Write-Ok "pip upgraded"
+}
 
 # ── Step 3: Detect GPU ──
 Write-Step "Detecting GPU..."


### PR DESCRIPTION
Fixes the silent-exit issue from #18: install.bat failed to install dependencies when a broken/half-built .venv folder was left behind from a prior install attempt.

## Root cause

The installer had this check (install.ps1, line 91):

```powershell
if (Test-Path ".venv\Scripts\python.exe") {
    Write-Ok "venv already exists, skipping"
} else {
    & $PythonCmd -m venv .venv
    ...
}
```

If the .venv folder was present but the python.exe inside was broken (different Python, partially created, or copied from elsewhere), the script skipped the recreate step and went straight to:

```powershell
& $Python -m pip install --upgrade pip --quiet
```

That call crashed silently ($ErrorActionPreference = "Stop" is set at the top of the script), the window closed, and the user was left with no dependencies installed — exactly the screenshot in #18.

## What I changed

- Added a `Test-VenvHealthy()` helper that actually invokes the venv's `python.exe --version` and verifies the output. If it returns a non-zero exit code or the version string doesn't match `Python X.Y`, the venv is considered broken.
- Replaced the file-existence check with a health check. If the venv is broken, the script now `Remove-Item -Recurse -Force .venv` and recreates it from scratch, so the user gets a working install.
- Added error handling around the `pip install --upgrade pip` step. A transient pip failure used to abort the whole installer; now it's logged as a warning and the install continues with the existing pip.

## Tested by

1. Created a fake broken venv: `mkdir .venv\Scripts && echo broken > .venv\Scripts\python.exe`. The old script silently exited at the pip step. The new script detects the broken venv, prints `Existing venv is broken or incomplete, recreating...` to the user, removes it, and continues.
2. With a healthy venv present, the script now prints `Existing venv is healthy, reusing` and proceeds normally — no regression.
3. With no .venv folder, the script creates one as before — no regression.

Closes #18