### PR TITLE
fix: 修复 #21/#20/#15 + 新增 uv 绿色版打包与 Actions 发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Build portable release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version label for the zip (optional, e.g. v1.0.0)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build portable zip
+        shell: pwsh
+        run: |
+          $version = "${{ github.event.inputs.version }}"
+          if (-not $version -and "${{ github.ref_type }}" -eq "tag") { $version = "${{ github.ref_name }}" }
+          if ($version) { ./build_release.ps1 -Version $version } else { ./build_release.ps1 }
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LiveTranslate-portable
+          path: release/*.zip
+
+      - name: Attach to GitHub Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ Desktop.ini
 # Distribution
 dist/
 build/
+release/
 *.egg-info/

--- a/asr_funasr_nano.py
+++ b/asr_funasr_nano.py
@@ -107,8 +107,8 @@ class FunASRNanoEngine:
         if not result or not result[0].get("text"):
             return None
 
-        raw_text = result[0]["text"]
-        text = result[0].get("text_tn", raw_text) or raw_text
+        # "text" keeps punctuation; "text_tn" strips it all via regex
+        text = result[0]["text"]
 
         # Clean special tags
         text = re.sub(r"<\|[^|]+\|>", "", text).strip()
@@ -118,7 +118,7 @@ class FunASRNanoEngine:
 
         detected_lang = self.language or self._guess_language(text)
 
-        log.debug(f"Raw: {raw_text} | ITN: {text}")
+        log.debug(f"ASR: {text}")
         return {
             "text": text,
             "language": detected_lang,

--- a/build_release.ps1
+++ b/build_release.ps1
@@ -1,0 +1,128 @@
+# LiveTranslate - Portable release builder
+# Produces a self-contained zip that runs without a system Python install.
+# First launch uses a bundled uv to fetch Python 3.12 + GPU-aware dependencies.
+
+param([string]$Version = "")
+
+$ErrorActionPreference = "Stop"
+$ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ProjectDir
+
+function Write-Step { param($msg) Write-Host "`n[BUILD] $msg" -ForegroundColor Cyan }
+function Write-Ok   { param($msg) Write-Host "  OK: $msg" -ForegroundColor Green }
+
+$UvUrl  = "https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-pc-windows-msvc.zip"
+$OutDir = Join-Path $ProjectDir "release"
+$Stage  = Join-Path $OutDir "LiveTranslate"
+
+$Sha   = (& git rev-parse --short HEAD).Trim()
+$Stamp = Get-Date -Format "yyyyMMdd"
+$Tag   = if ($Version) { $Version } else { "$Stamp-$Sha" }
+$ZipPath = Join-Path $OutDir "LiveTranslate-portable-$Tag.zip"
+
+# Files only needed for the git-clone workflow; the portable zip ships its own launcher.
+$DropList = @("install.bat", "install.ps1", "update.bat", "start.bat",
+              "build_release.ps1", "CLAUDE.md", "test_audio.py", ".gitignore", "screenshot")
+
+# ── 1. Clean staging ──
+Write-Step "Preparing staging directory..."
+if (Test-Path $OutDir) { Remove-Item -Recurse -Force $OutDir }
+New-Item -ItemType Directory -Force -Path $Stage | Out-Null
+
+# ── 2. Export tracked source via git archive ──
+Write-Step "Exporting source (git archive HEAD)..."
+$Tar = Join-Path $OutDir "src.tar"
+& git archive --format=tar -o $Tar HEAD
+if ($LASTEXITCODE -ne 0) { throw "git archive failed" }
+& tar -x -f $Tar -C $Stage
+Remove-Item $Tar
+foreach ($d in $DropList) {
+    $p = Join-Path $Stage $d
+    if (Test-Path $p) { Remove-Item -Recurse -Force $p }
+}
+Write-Ok "Source exported"
+
+# ── 3. Download and bundle uv ──
+Write-Step "Downloading uv..."
+$UvZip = Join-Path $OutDir "uv.zip"
+Invoke-WebRequest -Uri $UvUrl -OutFile $UvZip
+$ToolsDir = Join-Path $Stage "tools"
+New-Item -ItemType Directory -Force -Path $ToolsDir | Out-Null
+Expand-Archive -Path $UvZip -DestinationPath $ToolsDir -Force
+Remove-Item $UvZip
+$UvExe = Join-Path $ToolsDir "uv.exe"
+if (-not (Test-Path $UvExe)) { throw "uv.exe not found after extract" }
+Write-Ok ("Bundled " + (& $UvExe --version))
+
+# ── 4. Write portable launcher + bootstrap ──
+Write-Step "Writing launcher..."
+$StartBat = @'
+@echo off
+cd /d "%~dp0"
+if not exist ".venv\Scripts\python.exe" (
+    echo First run: setting up environment. This downloads Python and dependencies and may take several minutes...
+    powershell -ExecutionPolicy Bypass -File "%~dp0bootstrap.ps1"
+    if errorlevel 1 (
+        echo.
+        echo [ERROR] Setup failed. See messages above.
+        pause
+        exit /b 1
+    )
+)
+echo Starting LiveTranslate...
+.venv\Scripts\python.exe main.py
+if errorlevel 1 (
+    echo.
+    echo [ERROR] LiveTranslate exited with an error.
+    pause
+)
+'@
+Set-Content -Path (Join-Path $Stage "start.bat") -Value $StartBat -Encoding ASCII
+
+$Bootstrap = @'
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $Root
+$Uv = Join-Path $Root "tools\uv.exe"
+$env:UV_LINK_MODE = "copy"
+
+Write-Host "Creating virtual environment with Python 3.12..." -ForegroundColor Cyan
+& $Uv venv --python 3.12 --managed-python .venv
+if ($LASTEXITCODE -ne 0) { Write-Host "Failed to create venv" -ForegroundColor Red; exit 1 }
+$Py = ".venv\Scripts\python.exe"
+
+# Blackwell (sm_120+) needs cu128; older NVIDIA uses cu126; no GPU falls back to CPU
+$Index = "https://download.pytorch.org/whl/cpu"
+try {
+    $cc = & nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>$null
+    if ($LASTEXITCODE -eq 0 -and $cc) {
+        $cap = [double]($cc.Trim() -split "`n")[0]
+        if ($cap -ge 12.0) { $Index = "https://download.pytorch.org/whl/cu128" }
+        else { $Index = "https://download.pytorch.org/whl/cu126" }
+        Write-Host "NVIDIA GPU detected (compute $cap), using $Index" -ForegroundColor Green
+    }
+} catch {}
+if ($Index -like "*cpu*") { Write-Host "No NVIDIA GPU detected, installing CPU-only PyTorch" -ForegroundColor Yellow }
+
+Write-Host "Installing PyTorch (this may take a while)..." -ForegroundColor Cyan
+& $Uv pip install --python $Py torch torchaudio --index-url $Index
+if ($LASTEXITCODE -ne 0) { Write-Host "PyTorch install failed" -ForegroundColor Red; exit 1 }
+
+Write-Host "Installing dependencies..." -ForegroundColor Cyan
+& $Uv pip install --python $Py -r requirements.txt
+if ($LASTEXITCODE -ne 0) { Write-Host "Dependency install failed" -ForegroundColor Red; exit 1 }
+
+& $Uv pip install --python $Py funasr --no-deps
+& $Uv pip install --python $Py pysbd
+
+Write-Host "Setup complete." -ForegroundColor Green
+'@
+Set-Content -Path (Join-Path $Stage "bootstrap.ps1") -Value $Bootstrap -Encoding ASCII
+Write-Ok "Launcher written"
+
+# ── 5. Zip ──
+Write-Step "Creating archive..."
+Compress-Archive -Path $Stage -DestinationPath $ZipPath -Force
+$sizeMb = [math]::Round((Get-Item $ZipPath).Length / 1MB, 1)
+Write-Ok "Created $ZipPath ($sizeMb MB)"
+Write-Host "`nDone. Distribute: $ZipPath" -ForegroundColor Green

--- a/install.ps1
+++ b/install.ps1
@@ -19,17 +19,32 @@ Write-Host "========================================" -ForegroundColor Magenta
 Write-Step "Detecting Python..."
 
 function Find-Python {
+    # 3.13+ rejected: no ctranslate2 cp313 wheels (#15), strict SSL breaks torch.hub (#20)
+    foreach ($v in @("3.12", "3.11", "3.10")) {
+        try {
+            $exe = & py "-$v" -c "import sys; print(sys.executable)" 2>&1
+            if ($LASTEXITCODE -eq 0 -and $exe -and (Test-Path $exe.Trim())) {
+                $exe = $exe.Trim()
+                $ver = & $exe --version 2>&1
+                Write-Ok "Found $ver ($exe)"
+                return $exe
+            }
+        } catch {}
+    }
+    # Fall back to plain commands, rejecting unsupported versions.
     foreach ($cmd in @("python", "python3", "py")) {
         try {
             $ver = & $cmd --version 2>&1
             if ($ver -match "Python (\d+)\.(\d+)") {
                 $major = [int]$Matches[1]
                 $minor = [int]$Matches[2]
-                if ($major -eq 3 -and $minor -ge 10) {
+                if ($major -eq 3 -and $minor -ge 10 -and $minor -le 12) {
                     Write-Ok "Found $ver ($cmd)"
                     return $cmd
+                } elseif ($major -eq 3 -and $minor -ge 13) {
+                    Write-Warn "$ver is too new (faster-whisper/SSL require 3.10-3.12)"
                 } else {
-                    Write-Warn "$ver is too old (need 3.10+)"
+                    Write-Warn "$ver is too old (need 3.10-3.12)"
                 }
             }
         } catch {}

--- a/model_manager.py
+++ b/model_manager.py
@@ -170,13 +170,46 @@ def download_silero():
     import torch
 
     log.info("Downloading Silero VAD...")
-    model, _ = torch.hub.load(
-        repo_or_dir="snakers4/silero-vad",
-        model="silero_vad",
-        trust_repo=True,
-    )
+    try:
+        model, _ = torch.hub.load(
+            repo_or_dir="snakers4/silero-vad",
+            model="silero_vad",
+            trust_repo=True,
+        )
+    except Exception as exc:
+        if "CERTIFICATE_VERIFY" not in str(exc):
+            raise
+        log.warning("SSL strict verification failed, retrying with relaxed flags")
+        model, _ = _load_silero_relaxed_ssl()
     del model
     log.info("Silero VAD downloaded")
+
+
+def _load_silero_relaxed_ssl():
+    # Python 3.13 enables VERIFY_X509_STRICT by default, rejecting certificates
+    # without an Authority Key Identifier (common behind SSL-inspecting proxies).
+    import ssl
+
+    import torch
+
+    strict = getattr(ssl, "VERIFY_X509_STRICT", 0)
+    original = ssl._create_default_https_context
+
+    def relaxed_context(*args, **kwargs):
+        ctx = ssl.create_default_context(*args, **kwargs)
+        ctx.verify_flags &= ~strict
+        return ctx
+
+    ssl._create_default_https_context = relaxed_context
+    try:
+        return torch.hub.load(
+            repo_or_dir="snakers4/silero-vad",
+            model="silero_vad",
+            trust_repo=True,
+            force_reload=True,
+        )
+    finally:
+        ssl._create_default_https_context = original
 
 
 def download_asr(engine, model_size="medium", hub="ms"):


### PR DESCRIPTION
@
## 概述

修复 3 个 issue，并新增免装 Python 的"绿色版"打包方案。

## Bug 修复

- **#21 Fun-ASR-nano 输出丢标点**：改用带标点的 `text` 字段，不再取被正则过滤掉所有标点的 `text_tn`。
- **#20 Silero 下载 SSL 证书报错**：Python 3.13 默认开启 `VERIFY_X509_STRICT`，对缺少 AKI 的证书报 `Missing Authority Key Identifier`。`download_silero` 捕获证书校验失败后清除该 strict 标志重试一次。
- **#15 双击 start.bat 报错**：根因是 Python 3.13 太新（`ctranslate2` 无 cp313 wheel）。`install.ps1` 的 `Find-Python` 限制为 3.10–3.12、优先 3.12，并返回绝对 exe 路径。

## 新增：绿色版打包

- `build_release.ps1`：本地一键出包。`git archive` 导出源码 + 捆绑 `uv`，**首次运行用 `--managed-python` 拉取托管 Python 3.12，用户无需安装任何 Python**；按显卡自动选 cu128/cu126/cpu 安装依赖。
- `.github/workflows/release.yml`：打 `v*` tag 或手动触发，在 `windows-latest` 构建并附加到 Release。

## 验证

- 三处修复均做了语法/边界/行为级验证（SSL 兜底用 mock 跑通；Find-Python 抽函数实跑 + 边界测试）。
- 绿色包已在本地完整首运通过：uv 建 3.12 venv → 装 torch 2.12+cu126 + 全部依赖 → 正常启动。
- 已验证机器上**完全没有 Python** 时 uv 自动下载便携 CPython 3.12 并建出可用环境。
@