### PR TITLE
chore: 升级 CI actions 版本 + 完善文案与 README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build portable zip
         shell: pwsh
@@ -29,7 +29,7 @@ jobs:
           if ($version) { ./build_release.ps1 -Version $version } else { ./build_release.ps1 }
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: LiveTranslate-portable
           path: release/*.zip

--- a/README.md
+++ b/README.md
@@ -39,11 +39,17 @@ See [English Changelog](i18n/CHANGELOG_en.md) | [中文更新日志](i18n/CHANGE
 ## Requirements
 
 - **OS**: Windows 10/11
-- **Python**: 3.10+
+- **Python**: 3.10–3.12 (or use the portable build)
 - **GPU** (recommended): NVIDIA + CUDA 12.6 (Blackwell GPUs like RTX 50xx require CUDA 12.8)
 - **Network**: Access to a translation API
 
 ## Quick Start
+
+### Portable build (no Python required, recommended for non-developers)
+
+Download `LiveTranslate-portable-*.zip` from [Releases](https://github.com/TheDeathDragon/LiveTranslate/releases), unzip, and double-click **`start.bat`**. The first run auto-downloads a portable Python 3.12 and installs GPU-aware dependencies — no Python installation needed.
+
+### From source
 
 ```bash
 git clone https://github.com/TheDeathDragon/LiveTranslate.git
@@ -51,7 +57,7 @@ cd LiveTranslate
 ```
 
 Double-click **`install.bat`** — the installer will:
-1. Detect Python 3.10+ (auto-install via winget if missing)
+1. Detect Python 3.10–3.12 (auto-install via winget if missing)
 2. Create a virtual environment
 3. Auto-detect NVIDIA GPU and let you choose CUDA / CPU PyTorch
 4. Install all dependencies

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,11 +39,17 @@ Windows 实时音频翻译工具。捕获系统音频（WASAPI loopback）和可
 ## 系统要求
 
 - **操作系统**：Windows 10/11
-- **Python**：3.10+
+- **Python**：3.10–3.12（绿色版免装）
 - **GPU**（推荐）：NVIDIA 显卡 + CUDA 12.6（RTX 50 系列等 Blackwell 架构需要 CUDA 12.8）
 - **网络**：需要访问翻译 API
 
 ## 快速开始
+
+### 绿色版（免装 Python，推荐新手）
+
+从 [Releases](https://github.com/TheDeathDragon/LiveTranslate/releases) 下载 `LiveTranslate-portable-*.zip`，解压后双击 **`start.bat`** 即可。首次运行会自动下载便携版 Python 3.12 并按显卡安装依赖，无需预装任何 Python。
+
+### 从源码安装
 
 ```bash
 git clone https://github.com/TheDeathDragon/LiveTranslate.git
@@ -51,7 +57,7 @@ cd LiveTranslate
 ```
 
 双击 **`install.bat`** 一键安装——脚本会自动：
-1. 检测 Python 3.10+（未安装则通过 winget 自动安装）
+1. 检测 Python 3.10–3.12（未安装则通过 winget 自动安装）
 2. 创建虚拟环境
 3. 检测 NVIDIA 显卡，选择 CUDA / CPU 版 PyTorch
 4. 安装全部依赖

--- a/install.ps1
+++ b/install.ps1
@@ -55,7 +55,7 @@ function Find-Python {
 $PythonCmd = Find-Python
 
 if (-not $PythonCmd) {
-    Write-Warn "Python 3.10+ not found"
+    Write-Warn "No supported Python (3.10-3.12) found"
 
     # Try to install via winget
     $hasWinget = $false
@@ -87,12 +87,12 @@ if (-not $PythonCmd) {
                 exit 1
             }
         } else {
-            Write-Err "Python 3.10+ is required. Please install from https://www.python.org/downloads/"
+            Write-Err "Python 3.10-3.12 is required. Please install from https://www.python.org/downloads/"
             Read-Host "Press Enter to exit"
             exit 1
         }
     } else {
-        Write-Err "Python 3.10+ not found and winget is not available."
+        Write-Err "Python 3.10-3.12 not found and winget is not available."
         Write-Host "  Please install Python from https://www.python.org/downloads/" -ForegroundColor Yellow
         Write-Host "  Make sure to check 'Add Python to PATH' during installation." -ForegroundColor Yellow
         Read-Host "Press Enter to exit"


### PR DESCRIPTION
@
跟进 PR #23 的收尾改动：

- **CI**：`actions/checkout` v4→v6、`actions/upload-artifact` v4→v7，消除 Node.js 20 弃用警告（已在 runner 实跑验证，黄字警告消失）。
- **install.ps1**：提示文案 `3.10+` 统一为 `3.10-3.12`，与版本门限一致。
- **README（中/英）**：新增「绿色版（免装 Python）」下载说明，系统要求更新为 3.10-3.12。
@